### PR TITLE
Add GDB dependency for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Most used features have already been ported.
 ### Arch (Artix, Manjaro, etc.)
 
 ```sh
-sudo pacman -S git make gcc cjson sdl2 glew
+sudo pacman -S git make gcc cjson sdl2 glew gdb
 ```
 
 ### Debian (Ubuntu, etc.)


### PR DESCRIPTION
From `Extra` repo for Arch Linux. https://archlinux.org/packages/extra/x86_64/gdb/